### PR TITLE
Set julia compat to 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedSubdivisions"
 uuid = "291d046c-3347-11e9-1e74-c3d251d406c6"
 authors = ["Sascha Timme <sascha.timme@gmail.com>"]
-version = "1.1.6"
+version = "1.2.0-DEV"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,7 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 MultivariatePolynomials = "^0.5"
 ProgressMeter = "^1.10"
 StaticArrays = "^0.9, ^0.10, ^0.11, ^0.12, ^1.0"
-julia = "1"
+julia = "1.6"
 
 [extras]
 MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"


### PR DESCRIPTION
This project uses the `import PackageName as Something` syntax that was not available in julia 1.0, but was only added in 1.6.
This PR updates the julia compat bound to reflect that.

Since changing the julia compat bound is not allowed in a patch release, I already bumped the minor part of the version number.

This came up in https://github.com/oscar-system/Oscar.jl/issues/5592, as newer julia versions (julia 1.14.DEV since a few days ago) won't allow loading of MixedSubdivision.jl due to this anymore. Even though I would consider this a breaking change in julia itself (see https://github.com/JuliaLang/julia/issues/60273), this should (at least in the mid-term future) be changed here.

cc @benlorenz