### PR TITLE
Update julia versions in CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,10 +13,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          julia-version: ['^1.5', '^1.6.0-0']
+          julia-version:
+            - '1.6'   # minimum supported version
+            - 'lts'   # latest LTS version
+            - '1'     # latest stable version
+            - 'pre'   # latest pre-release version
           os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}


### PR DESCRIPTION
Previously, both `^1.5` and `^1.6.0-0` resolved to the latest stable release due to the `^` (aka 1.12.2 right now).
This PR updates this to instead test against the oldest julia version this works with 1.6 (see https://github.com/saschatimme/MixedSubdivisions.jl/pull/32), the two julia versions that are supported by the julia people (lts and stable), as well as the latest prerelease to notice issues before a release.

That way, you will notice once you use any features that require newer versions than julia 1.6, and can then update the julia compat and the julia version in the CI script accordingly.

cc @benlorenz